### PR TITLE
BIGTOP-4120. Fix CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,19 @@ jobs:
         java: ['17', '21']
     services:
       db:
-        image: mysql:8.0
+        image: postgres
         ports:
-          - 3306:3306
+          - 5432:5432
         env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: bigtop_manager
+          POSTGRES_DB: bigtop_manager
+          POSTGRES_PASSWORD: postgres
+      prom:
+        image: prom/prometheus
+        ports:
+          - 9090:9090
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/bigtop-manager-server/src/main/resources/assembly/server.xml
+++ b/bigtop-manager-server/src/main/resources/assembly/server.xml
@@ -44,8 +44,8 @@
         <fileSet>
             <directory>${basedir}/src/main/resources/stacks</directory>
             <outputDirectory>stacks</outputDirectory>
-            <fileMode>0644</fileMode>
-            <directoryMode>0644</directoryMode>
+            <fileMode>0755</fileMode>
+            <directoryMode>0755</directoryMode>
         </fileSet>
         <fileSet>
             <directory>${basedir}/../bigtop-manager-ui/dist</directory>

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,7 @@
                         <exclude>**/*.ftl</exclude>
                         <exclude>**/*.log</exclude>
                         <exclude>pnpm-lock.yaml</exclude>
+                        <exclude>**/target/**</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Currently, CI job fails due to the lack of prerequisite services and wrong directory permission. This PR fixes them.