### PR TITLE
Add HADOOP_JAVA_HOME variable, due to different java version …

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,40 @@ monitoring:
   prometheus-host: "http://localhost:9090"
   agent-host-job-name: "bm-agent-host"
 ```
+
+## Installation
+Apache Bigtop-Manager need Java 17.  
+Apache Hadoop 3.3 and upper supports Java 8 and Java 11 (runtime only).
+
+So we need to setup both of them, add JAVA_HOME and HADOOP_JAVA_HOME environment variables to all machines (where server and agents will be installed)
+```
+export JAVA_HOME=
+export HADOOP_JAVA_HOME=
+```
+
+### Controlling instances
+
+### Server
+#### Start server
+```
+cd bigtop-manager-server/
+sudo -E nohup ./bin/start.sh --debug >/dev/null 2>&1 &
+```
+
+#### Stop server
+```
+sudo kill -9 $(ps -aux | grep ServerApplication | grep -v grep | awk '{print $2}')
+```
+
+### Agent
+#### Start agent
+```
+cd bigtop-manager-agent/
+sudo -E nohup ./bin/start.sh --debug >/dev/null 2>&1 &
+```
+
+#### Stop agent
+```
+sudo kill -9 $(ps -aux | grep AgentApplication | grep -v grep | awk '{print $2}')
+
+

--- a/bigtop-manager-common/src/main/java/org/apache/bigtop/manager/common/utils/Environments.java
+++ b/bigtop-manager-common/src/main/java/org/apache/bigtop/manager/common/utils/Environments.java
@@ -43,16 +43,23 @@ public class Environments {
      * @return java home string
      */
     public static String getJavaHome() {
-        // Retrieve the JAVA_HOME environment variable
-        String javaHome = System.getenv("JAVA_HOME");
+        // Retrieve the HADOOP_JAVA_HOME environment variable
+        String hadoopJavaHome = System.getenv("HADOOP_JAVA_HOME");
 
-        // Check if JAVA_HOME is set
-        if (javaHome != null) {
-            return javaHome;
+        if (hadoopJavaHome != null) {
+            return hadoopJavaHome;
         } else {
-            // If JAVA_HOME is not set, use the java.home system property
-            log.info("JAVA_HOME is not set, using java.home system property instead.");
-            return System.getProperty("java.home");
+            // Retrieve the JAVA_HOME environment variable
+            String javaHome = System.getenv("JAVA_HOME");
+
+            // Check if JAVA_HOME is set
+            if (javaHome != null) {
+                return javaHome;
+            } else {
+                // If JAVA_HOME is not set, use the java.home system property
+                log.info("JAVA_HOME is not set, using java.home system property instead.");
+                return System.getProperty("java.home");
+            }
         }
     }
 }

--- a/bigtop-manager-server/src/main/resources/stacks/bigtop/3.3.0/services/hdfs/metainfo.xml
+++ b/bigtop-manager-server/src/main/resources/stacks/bigtop/3.3.0/services/hdfs/metainfo.xml
@@ -58,9 +58,9 @@
                 <quick-link>
                     <display-name>NameNode UI</display-name>
                     <http-port-property>dfs.namenode.http-address</http-port-property>
-                    <http-port-default>50070</http-port-default>
+                    <http-port-default>9870</http-port-default>
                     <https-port-property>dfs.namenode.http-address</https-port-property>
-                    <https-port-default>50470</https-port-default>
+                    <https-port-default>9865</https-port-default>
                 </quick-link>
             </component>
             <component>


### PR DESCRIPTION
Hadoop - Browse Directory got Error.

**Issue:**
Issue relates to JDK version incompability:
Apache Bigtop-Manager need Java 17.  
Apache Hadoop 3.3 and upper supports Java 8 and Java 11 (runtime only).

**Solution**
So we need to setup both of them, add JAVA_HOME and HADOOP_JAVA_HOME environment variables.
JAVA_HOME used by Bigtop-Manager and HADOOP_JAVA_HOME used by Hadoop accordingly.

http://hostname:9870/explorer.html#/

![image](https://github.com/user-attachments/assets/e45ea8cd-74f9-4f37-9e46-d4482e30ee8b)

```
2024-10-17 15:56:36,512 WARN org.eclipse.jetty.server.HttpChannel: /webhdfs/v1/
java.lang.ExceptionInInitializerError
        at com.sun.xml.bind.v2.runtime.reflect.opt.AccessorInjector.prepare(AccessorInjector.java:83)
        at com.sun.xml.bind.v2.runtime.reflect.opt.OptimizedAccessorFactory.get(OptimizedAccessorFactory.java:176)
        at com.sun.xml.bind.v2.runtime.reflect.Accessor$FieldReflection.optimize(Accessor.java:282)
        at com.sun.xml.bind.v2.runtime.property.ArrayProperty.<init>(ArrayProperty.java:69)
        at com.sun.xml.bind.v2.runtime.property.ArrayERProperty.<init>(ArrayERProperty.java:88)
        at com.sun.xml.bind.v2.runtime.property.ArrayElementProperty.<init>(ArrayElementProperty.java:100)
        at com.sun.xml.bind.v2.runtime.property.ArrayElementNodeProperty.<init>(ArrayElementNodeProperty.java:62)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481)
        at com.sun.xml.bind.v2.runtime.property.PropertyFactory.create(PropertyFactory.java:128)
        at com.sun.xml.bind.v2.runtime.ClassBeanInfoImpl.<init>(ClassBeanInfoImpl.java:183)
        at com.sun.xml.bind.v2.runtime.JAXBContextImpl.getOrCreate(JAXBContextImpl.java:532)
        at com.sun.xml.bind.v2.runtime.JAXBContextImpl.<init>(JAXBContextImpl.java:347)
        at com.sun.xml.bind.v2.runtime.JAXBContextImpl$JAXBContextBuilder.build(JAXBContextImpl.java:1170)
        at com.sun.xml.bind.v2.ContextFactory.createContext(ContextFactory.java:145)
        at com.sun.xml.bind.v2.ContextFactory.createContext(ContextFactory.java:236)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at javax.xml.bind.ContextFinder.newInstance(ContextFinder.java:186)
        at javax.xml.bind.ContextFinder.newInstance(ContextFinder.java:146)
        at javax.xml.bind.ContextFinder.find(ContextFinder.java:350)
        at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:446)
        at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:409)
        at com.sun.jersey.server.impl.wadl.WadlApplicationContextImpl.<init>(WadlApplicationContextImpl.java:103)
        at com.sun.jersey.server.impl.wadl.WadlFactory.init(WadlFactory.java:100)
        at com.sun.jersey.server.impl.application.RootResourceUriRules.initWadl(RootResourceUriRules.java:169)
        at com.sun.jersey.server.impl.application.RootResourceUriRules.<init>(RootResourceUriRules.java:106)
        at com.sun.jersey.server.impl.application.WebApplicationImpl._initiate(WebApplicationImpl.java:1359)
        at com.sun.jersey.server.impl.application.WebApplicationImpl.access$700(WebApplicationImpl.java:180)
        at com.sun.jersey.server.impl.application.WebApplicationImpl$13.f(WebApplicationImpl.java:799)
        at com.sun.jersey.server.impl.application.WebApplicationImpl$13.f(WebApplicationImpl.java:795)
        at com.sun.jersey.spi.inject.Errors.processWithErrors(Errors.java:193)
        at com.sun.jersey.server.impl.application.WebApplicationImpl.initiate(WebApplicationImpl.java:795)
        at com.sun.jersey.server.impl.application.WebApplicationImpl.initiate(WebApplicationImpl.java:790)
        at com.sun.jersey.spi.container.servlet.ServletContainer.initiate(ServletContainer.java:509)
        at com.sun.jersey.spi.container.servlet.ServletContainer$InternalWebComponent.initiate(ServletContainer.java:339)
        at com.sun.jersey.spi.container.servlet.WebComponent.load(WebComponent.java:605)
        at com.sun.jersey.spi.container.servlet.WebComponent.init(WebComponent.java:207)
        at com.sun.jersey.spi.container.servlet.ServletContainer.init(ServletContainer.java:394)
        at com.sun.jersey.spi.container.servlet.ServletContainer.init(ServletContainer.java:577)
        at javax.servlet.GenericServlet.init(GenericServlet.java:244)
        at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:632)
        at org.eclipse.jetty.servlet.ServletHolder.getServlet(ServletHolder.java:486)
        at org.eclipse.jetty.servlet.ServletHolder.prepare(ServletHolder.java:759)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:549)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
        at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:600)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:235)
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1440)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:505)
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1594)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1355)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
        at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:146)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
        at org.eclipse.jetty.server.Server.handle(Server.java:516)
        at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:487)
        at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:732)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:479)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
        at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034)
        at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @521e4dbf
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
        at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:200)
        at java.base/java.lang.reflect.Method.setAccessible(Method.java:194)
        at com.sun.xml.bind.v2.runtime.reflect.opt.Injector$1.run(Injector.java:177)
        at com.sun.xml.bind.v2.runtime.reflect.opt.Injector$1.run(Injector.java:174)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
        at com.sun.xml.bind.v2.runtime.reflect.opt.Injector.<clinit>(Injector.java:172)
        ... 81 more
```

