### PR TITLE
Remove JDK-17 specific flag.

### DIFF
--- a/bigtop-manager-server/src/main/resources/stacks/bigtop/3.3.0/services/yarn/configuration/yarn-env.xml
+++ b/bigtop-manager-server/src/main/resources/stacks/bigtop/3.3.0/services/yarn/configuration/yarn-env.xml
@@ -201,7 +201,6 @@ fi
 HADOOP_OPTS="$HADOOP_OPTS -Dyarn.policy.file=$YARN_POLICYFILE"
 </#noparse>
 HADOOP_OPTS="$HADOOP_OPTS -Djava.io.tmpdir=${hadoop_java_io_tmpdir}"
-HADOOP_OPTS="$HADOOP_OPTS --add-opens java.base/java.lang=ALL-UNNAMED"
 ]]>
         </value>
         <attrs>


### PR DESCRIPTION
Due to Apache Hadoop 3.3 and upper supports Java 8 and Java 11 (runtime only), there is no reason to try to start it with JDK 17.

So we need to remove JDK 17 keys in YARN env file.

--add-opens - does not exits in both 8 and 11 and prevent to start Resource Server.

Resource manager log:
```
Unrecognized option: --add-opens
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
real-time non-blocking time  (microseconds, -R) unlimited
core file size              (blocks, -c) 0
data seg size               (kbytes, -d) unlimited
scheduling priority                 (-e) 0
file size                   (blocks, -f) unlimited
pending signals                     (-i) 63848
max locked memory           (kbytes, -l) 2047542
max memory size             (kbytes, -m) unlimited
open files                          (-n) 32768
pipe size                (512 bytes, -p) 8
POSIX message queues         (bytes, -q) 819200
real-time priority                  (-r) 0
stack size                  (kbytes, -s) 8192
cpu time                   (seconds, -t) unlimited
max user processes                  (-u) 65536
virtual memory              (kbytes, -v) unlimited
file locks                          (-x) unlimited
```