### PR TITLE
BIGTOP-4362: Remove the icon from "Create Cluster" button

### DIFF
--- a/bigtop-manager-ui/src/layouts/default.vue
+++ b/bigtop-manager-ui/src/layouts/default.vue
@@ -27,7 +27,7 @@
       <img :src="usePngImage('default')" />
       <a-typography-text>{{ $t('cluster.cluster_unavailable_message') }}</a-typography-text>
       <a-typography-link underline @click="() => $router.push({ name: 'ClusterCreate' })">
-        {{ $t('cluster.create') }}
+        {{ $t('menu.create') }}
       </a-typography-link>
     </div>
   </a-card>

--- a/bigtop-manager-ui/src/layouts/sider.vue
+++ b/bigtop-manager-ui/src/layouts/sider.vue
@@ -106,7 +106,6 @@
       <div class="create-option">
         <a-button type="primary" ghost @click="addCluster">
           <div>
-            <svg-icon style="margin-left: 0" name="plus" />
             <label>{{ $t('menu.create') }}</label>
           </div>
         </a-button>
@@ -148,7 +147,6 @@
         width: 160px;
         @include flexbox($align: center, $justify: center);
         label {
-          margin-left: 10px;
           cursor: pointer;
         }
       }


### PR DESCRIPTION
1. remove the icon from the "Create Cluster" button in the left-hand menu of the main layout to ensure the text is centered.
2. change the i18n code "Create Cluster" button in main layout.