### PR TITLE
BIGTOP-4416: Fix  Docker build error by DockerFile.rocky8 (arm system)

### DIFF
--- a/dev-support/docker/containers/build.sh
+++ b/dev-support/docker/containers/build.sh
@@ -75,7 +75,7 @@ create_container() {
       docker run -itd --name ${container_name} --hostname ${container_name} --network bigtop-manager --cap-add=SYS_TIME bigtop-manager/develop:${OS}
     fi
 
-    docker exec ${container_name} bash -c "echo '$SERVER_PUB_KEY' > /root/.ssh/authorized_keys"
+    docker exec ${container_name} bash -c "mkdir -p /root/.ssh && echo '$SERVER_PUB_KEY' > /root/.ssh/authorized_keys"
     docker exec ${container_name} ssh-keygen -N '' -t rsa -b 2048 -f /etc/ssh/ssh_host_rsa_key
     docker exec ${container_name} ssh-keygen -N '' -t ecdsa -b 256 -f /etc/ssh/ssh_host_ecdsa_key
     docker exec ${container_name} ssh-keygen -N '' -t ed25519 -b 256 -f /etc/ssh/ssh_host_ed25519_key

--- a/dev-support/docker/image/Dockerfile.rocky8
+++ b/dev-support/docker/image/Dockerfile.rocky8
@@ -13,13 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rockylinux:8
+FROM rockylinux/rockylinux:8
 
 RUN yum -y install sudo wget openssh-clients openssh-server vim postgresql mariadb mariadb-server net-tools chrony krb5-server krb5-libs krb5-workstation git rpm-build python3 procps-ng
-RUN wget https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-x64_bin.tar.gz -O /tmp/jdk.tar.gz --no-check-certificate \
-  && mkdir -p /usr/local/java && tar -xzf /tmp/jdk.tar.gz -C /usr/local/java --strip-components=1 \
-  && rm -f /tmp/jdk.tar.gz \
-  && ln -s /usr/local/java/bin/java /usr/bin/java
+RUN dnf install -y postgresql java-17-openjdk-devel vim
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
+
 RUN wget https://archive.apache.org/dist/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz -O /tmp/apache-maven.tar.gz --no-check-certificate \
   && mkdir -p /usr/share/maven && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
   && rm -f /tmp/apache-maven.tar.gz \

--- a/dev-support/docker/image/build.sh
+++ b/dev-support/docker/image/build.sh
@@ -30,6 +30,9 @@ BIN_DIR=$(dirname $0)
 cd $BIN_DIR
 echo $PWD
 
+# Ensure the script has executable permissions
+chmod 755 build.sh
+
 if [ $# != 1 ]; then
   echo "Creates bigtop-manager/develop image"
   echo

--- a/dev-support/docker/image/build.sh
+++ b/dev-support/docker/image/build.sh
@@ -30,7 +30,6 @@ BIN_DIR=$(dirname $0)
 cd $BIN_DIR
 echo $PWD
 
-
 if [ $# != 1 ]; then
   echo "Creates bigtop-manager/develop image"
   echo

--- a/dev-support/docker/image/build.sh
+++ b/dev-support/docker/image/build.sh
@@ -30,8 +30,6 @@ BIN_DIR=$(dirname $0)
 cd $BIN_DIR
 echo $PWD
 
-# Ensure the script has executable permissions
-chmod 755 build.sh
 
 if [ $# != 1 ]; then
   echo "Creates bigtop-manager/develop image"


### PR DESCRIPTION
When I built an image using Dockerfile.rocky8 on my M2 Mac (ARM processor), the build failed to pull the rockylinux/rockylinux:8 image. After modifying the configuration, the build was successful. However, when I started the service, I found that no service was running. Upon entering the container, I discovered that the Java version being used was x64. I have now changed the JDK configuration to match that of openeuler24.
<img width="187" alt="62411745894623_ pic" src="https://github.com/user-attachments/assets/fb27eea0-d213-424e-b2b9-593f4a48105c" />
