### PR TITLE
refactor: replace langchain4j with Spring AI in bigtop-manager-ai module

### DIFF
--- a/bigtop-manager-ai/pom.xml
+++ b/bigtop-manager-ai/pom.xml
@@ -48,30 +48,8 @@
             <artifactId>bigtop-manager-dao</artifactId>
         </dependency>
         <dependency>
-            <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-reactor</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-open-ai</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-community-qianfan</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j-community-dashscope</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-simple</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-openai</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/bigtop-manager-ai/pom.xml
+++ b/bigtop-manager-ai/pom.xml
@@ -52,6 +52,10 @@
             <artifactId>spring-ai-openai</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-deepseek</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/assistant/GeneralAssistantFactory.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/assistant/GeneralAssistantFactory.java
@@ -68,8 +68,7 @@ public class GeneralAssistantFactory extends AbstractAIAssistantFactory {
     }
 
     @Override
-    public AIAssistant createWithPrompt(
-            AIAssistantConfig config, Object toolProvider, SystemPrompt systemPrompt) {
+    public AIAssistant createWithPrompt(AIAssistantConfig config, Object toolProvider, SystemPrompt systemPrompt) {
         GeneralAssistantConfig generalAssistantConfig = (GeneralAssistantConfig) config;
         PlatformType platformType = generalAssistantConfig.getPlatformType();
         Object id = generalAssistantConfig.getId();

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/assistant/GeneralAssistantFactory.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/assistant/GeneralAssistantFactory.java
@@ -34,8 +34,6 @@ import org.apache.bigtop.manager.ai.platform.QianFanAssistant;
 
 import org.springframework.stereotype.Component;
 
-import dev.langchain4j.service.tool.ToolProvider;
-
 import jakarta.annotation.Resource;
 import java.util.ArrayList;
 import java.util.List;
@@ -71,7 +69,7 @@ public class GeneralAssistantFactory extends AbstractAIAssistantFactory {
 
     @Override
     public AIAssistant createWithPrompt(
-            AIAssistantConfig config, ToolProvider toolProvider, SystemPrompt systemPrompt) {
+            AIAssistantConfig config, Object toolProvider, SystemPrompt systemPrompt) {
         GeneralAssistantConfig generalAssistantConfig = (GeneralAssistantConfig) config;
         PlatformType platformType = generalAssistantConfig.getPlatformType();
         Object id = generalAssistantConfig.getId();
@@ -81,9 +79,8 @@ public class GeneralAssistantFactory extends AbstractAIAssistantFactory {
 
         AIAssistant.Builder builder = initializeBuilder(platformType);
         builder.id(id)
-                .memoryStore(chatMemoryStoreProvider.createPersistentChatMemoryStore())
-                .withConfig(generalAssistantConfig)
-                .withToolProvider(toolProvider);
+                .memoryStore(chatMemoryStoreProvider.createPersistentChatMemoryStore(id))
+                .withConfig(generalAssistantConfig);
 
         configureSystemPrompt(builder, systemPrompt, generalAssistantConfig.getLanguage());
 
@@ -91,15 +88,14 @@ public class GeneralAssistantFactory extends AbstractAIAssistantFactory {
     }
 
     @Override
-    public AIAssistant createForTest(AIAssistantConfig config, ToolProvider toolProvider) {
+    public AIAssistant createForTest(AIAssistantConfig config, Object toolProvider) {
         GeneralAssistantConfig generalAssistantConfig = (GeneralAssistantConfig) config;
         PlatformType platformType = generalAssistantConfig.getPlatformType();
         AIAssistant.Builder builder = initializeBuilder(platformType);
 
         builder.id(null)
                 .memoryStore(chatMemoryStoreProvider.createInMemoryChatMemoryStore())
-                .withConfig(generalAssistantConfig)
-                .withToolProvider(toolProvider);
+                .withConfig(generalAssistantConfig);
 
         return builder.build();
     }

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/assistant/provider/ChatMemoryStoreProvider.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/assistant/provider/ChatMemoryStoreProvider.java
@@ -22,10 +22,10 @@ import org.apache.bigtop.manager.ai.assistant.store.PersistentChatMemoryStore;
 import org.apache.bigtop.manager.dao.repository.ChatMessageDao;
 import org.apache.bigtop.manager.dao.repository.ChatThreadDao;
 
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.stereotype.Component;
-
-import dev.langchain4j.store.memory.chat.ChatMemoryStore;
-import dev.langchain4j.store.memory.chat.InMemoryChatMemoryStore;
 
 import jakarta.annotation.Resource;
 
@@ -37,11 +37,16 @@ public class ChatMemoryStoreProvider {
     @Resource
     private ChatMessageDao chatMessageDao;
 
-    public ChatMemoryStore createPersistentChatMemoryStore() {
-        return new PersistentChatMemoryStore(chatThreadDao, chatMessageDao);
+    public ChatMemory createPersistentChatMemoryStore(Object conversationId) {
+        PersistentChatMemoryStore repository = new PersistentChatMemoryStore((Long)conversationId, chatThreadDao, chatMessageDao);
+        return MessageWindowChatMemory.builder()
+                .chatMemoryRepository(repository)
+                .build();
     }
 
-    public ChatMemoryStore createInMemoryChatMemoryStore() {
-        return new InMemoryChatMemoryStore();
+    public ChatMemory createInMemoryChatMemoryStore() {
+        return MessageWindowChatMemory.builder()
+                .chatMemoryRepository(new InMemoryChatMemoryRepository())
+                .build();
     }
 }

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/assistant/provider/ChatMemoryStoreProvider.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/assistant/provider/ChatMemoryStoreProvider.java
@@ -38,7 +38,8 @@ public class ChatMemoryStoreProvider {
     private ChatMessageDao chatMessageDao;
 
     public ChatMemory createPersistentChatMemoryStore(Object conversationId) {
-        PersistentChatMemoryStore repository = new PersistentChatMemoryStore((Long)conversationId, chatThreadDao, chatMessageDao);
+        PersistentChatMemoryStore repository =
+                new PersistentChatMemoryStore((Long) conversationId, chatThreadDao, chatMessageDao);
         return MessageWindowChatMemory.builder()
                 .chatMemoryRepository(repository)
                 .build();

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/assistant/store/PersistentChatMemoryStore.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/assistant/store/PersistentChatMemoryStore.java
@@ -24,12 +24,11 @@ import org.apache.bigtop.manager.dao.po.ChatThreadPO;
 import org.apache.bigtop.manager.dao.repository.ChatMessageDao;
 import org.apache.bigtop.manager.dao.repository.ChatThreadDao;
 
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.ChatMessageType;
-import dev.langchain4j.data.message.SystemMessage;
-import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
@@ -38,41 +37,49 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Slf4j
-public class PersistentChatMemoryStore implements ChatMemoryStore {
+public class PersistentChatMemoryStore implements ChatMemoryRepository {
 
-    private final List<ChatMessage> messagesInMemory = new ArrayList<>();
+    private final List<Message> messagesInMemory = new ArrayList<>();
     private final ChatThreadDao chatThreadDao;
     private final ChatMessageDao chatMessageDao;
+    private final Long conversationId;
 
-    public PersistentChatMemoryStore(ChatThreadDao chatThreadDao, ChatMessageDao chatMessageDao) {
+    public PersistentChatMemoryStore(Long conversationId, ChatThreadDao chatThreadDao, ChatMessageDao chatMessageDao) {
+        this.conversationId = conversationId;
         this.chatThreadDao = chatThreadDao;
         this.chatMessageDao = chatMessageDao;
     }
 
-    private ChatMessage convertToChatMessage(ChatMessagePO chatMessagePO) {
+    private Message convertToChatMessage(ChatMessagePO chatMessagePO) {
         String sender = chatMessagePO.getSender().toLowerCase();
         if (sender.equals(MessageType.AI.getValue())) {
-            return new AiMessage(chatMessagePO.getMessage());
+            return new AssistantMessage(chatMessagePO.getMessage());
         } else if (sender.equals(MessageType.USER.getValue())) {
             return new UserMessage(chatMessagePO.getMessage());
+        } else if (sender.equals(MessageType.SYSTEM.getValue())) {
+            return new SystemMessage(chatMessagePO.getMessage());
         } else {
             return null;
         }
     }
 
-    private ChatMessagePO convertToChatMessagePO(ChatMessage chatMessage, Long chatThreadId) {
+    private ChatMessagePO convertToChatMessagePO(Message message, Long chatThreadId) {
         ChatMessagePO chatMessagePO = new ChatMessagePO();
-        if (chatMessage.type().equals(ChatMessageType.AI)) {
+        if (message.getMessageType() == org.springframework.ai.chat.messages.MessageType.ASSISTANT) {
             chatMessagePO.setSender(MessageType.AI.getValue());
-            AiMessage aiMessage = (AiMessage) chatMessage;
-            if (aiMessage.text() == null) {
+            AssistantMessage assistantMessage = (AssistantMessage) message;
+            if (assistantMessage.getText() == null) {
                 return null;
             }
-            chatMessagePO.setMessage(aiMessage.text());
-        } else if (chatMessage.type().equals(ChatMessageType.USER)) {
+            chatMessagePO.setMessage(assistantMessage.getText());
+        } else if (message.getMessageType() == org.springframework.ai.chat.messages.MessageType.USER) {
             chatMessagePO.setSender(MessageType.USER.getValue());
-            UserMessage userMessage = (UserMessage) chatMessage;
-            chatMessagePO.setMessage(userMessage.singleText());
+            UserMessage userMessage = (UserMessage) message;
+            chatMessagePO.setMessage(userMessage.getText());
+        } else if (message.getMessageType() == org.springframework.ai.chat.messages.MessageType.SYSTEM) {
+            chatMessagePO.setSender(MessageType.SYSTEM.getValue());
+            SystemMessage systemMessage = (SystemMessage) message;
+            chatMessagePO.setMessage(systemMessage.getText());
         } else {
             return null;
         }
@@ -82,11 +89,11 @@ public class PersistentChatMemoryStore implements ChatMemoryStore {
         return chatMessagePO;
     }
 
-    private List<ChatMessage> sortMessages(List<ChatMessage> messages) {
-        List<ChatMessage> systemMessages = messages.stream()
+    private List<Message> sortMessages(List<Message> messages) {
+        List<Message> systemMessages = messages.stream()
                 .filter(message -> message instanceof SystemMessage)
                 .collect(Collectors.toList());
-        List<ChatMessage> otherMessages = messages.stream()
+        List<Message> otherMessages = messages.stream()
                 .filter(message -> !(message instanceof SystemMessage))
                 .toList();
 
@@ -95,9 +102,15 @@ public class PersistentChatMemoryStore implements ChatMemoryStore {
     }
 
     @Override
-    public List<ChatMessage> getMessages(Object threadId) {
-        List<ChatMessagePO> chatMessages = chatMessageDao.findAllByThreadId((Long) threadId);
-        List<ChatMessage> allChatMessages = new ArrayList<>();
+    public List<String> findConversationIds() {
+        // Return the current conversation ID as a list
+        return List.of(String.valueOf(conversationId));
+    }
+
+    @Override
+    public List<Message> findByConversationId(String conversationId) {
+        List<ChatMessagePO> chatMessages = chatMessageDao.findAllByThreadId(this.conversationId);
+        List<Message> allChatMessages = new ArrayList<>();
         if (!chatMessages.isEmpty()) {
             allChatMessages.addAll(chatMessages.stream()
                     .map(this::convertToChatMessage)
@@ -111,20 +124,22 @@ public class PersistentChatMemoryStore implements ChatMemoryStore {
     }
 
     @Override
-    public void updateMessages(Object threadId, List<ChatMessage> messages) {
-        ChatMessage newMessage = messages.get(messages.size() - 1);
-        ChatMessagePO chatMessagePO = convertToChatMessagePO(newMessage, (Long) threadId);
-        if (chatMessagePO == null) {
-            messagesInMemory.add(newMessage);
-            return;
+    public void saveAll(String conversationId, List<Message> messages) {
+        for (Message message : messages) {
+            ChatMessagePO chatMessagePO = convertToChatMessagePO(message, this.conversationId);
+            if (chatMessagePO == null) {
+                messagesInMemory.add(message);
+                continue;
+            }
+            chatMessageDao.save(chatMessagePO);
         }
-        chatMessageDao.save(chatMessagePO);
     }
 
     @Override
-    public void deleteMessages(Object threadId) {
-        List<ChatMessagePO> chatMessagePOS = chatMessageDao.findAllByThreadId((Long) threadId);
+    public void deleteByConversationId(String conversationId) {
+        List<ChatMessagePO> chatMessagePOS = chatMessageDao.findAllByThreadId(this.conversationId);
         chatMessagePOS.forEach(chatMessage -> chatMessage.setIsDeleted(true));
         chatMessageDao.partialUpdateByIds(chatMessagePOS);
+        messagesInMemory.clear();
     }
 }

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/assistant/store/PersistentChatMemoryStore.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/assistant/store/PersistentChatMemoryStore.java
@@ -29,6 +29,7 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
+
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/core/AbstractAIAssistant.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/core/AbstractAIAssistant.java
@@ -24,6 +24,7 @@ import org.apache.bigtop.manager.ai.core.factory.AIAssistant;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
+
 import reactor.core.publisher.Flux;
 
 public abstract class AbstractAIAssistant implements AIAssistant {

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/core/factory/AIAssistant.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/core/factory/AIAssistant.java
@@ -1,31 +1,11 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package org.apache.bigtop.manager.ai.core.factory;
 
 import org.apache.bigtop.manager.ai.core.config.AIAssistantConfig;
 import org.apache.bigtop.manager.ai.core.enums.PlatformType;
 
-import dev.langchain4j.memory.ChatMemory;
-import dev.langchain4j.model.chat.ChatModel;
-import dev.langchain4j.model.chat.StreamingChatModel;
-import dev.langchain4j.service.tool.ToolProvider;
-import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.StreamingChatModel;
 import reactor.core.publisher.Flux;
 
 public interface AIAssistant {
@@ -72,11 +52,9 @@ public interface AIAssistant {
     interface Builder {
         Builder id(Object id);
 
-        Builder memoryStore(ChatMemoryStore memoryStore);
+        Builder memoryStore(ChatMemory memoryStore);
 
         Builder withConfig(AIAssistantConfig configProvider);
-
-        Builder withToolProvider(ToolProvider toolProvider);
 
         Builder withSystemPrompt(String systemPrompt);
 

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/core/factory/AIAssistant.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/core/factory/AIAssistant.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.bigtop.manager.ai.core.factory;
 
 import org.apache.bigtop.manager.ai.core.config.AIAssistantConfig;
@@ -6,6 +24,7 @@ import org.apache.bigtop.manager.ai.core.enums.PlatformType;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.StreamingChatModel;
+
 import reactor.core.publisher.Flux;
 
 public interface AIAssistant {

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/core/factory/AIAssistantFactory.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/core/factory/AIAssistantFactory.java
@@ -21,15 +21,13 @@ package org.apache.bigtop.manager.ai.core.factory;
 import org.apache.bigtop.manager.ai.core.config.AIAssistantConfig;
 import org.apache.bigtop.manager.ai.core.enums.SystemPrompt;
 
-import dev.langchain4j.service.tool.ToolProvider;
-
 public interface AIAssistantFactory {
 
-    AIAssistant createWithPrompt(AIAssistantConfig config, ToolProvider toolProvider, SystemPrompt systemPrompt);
+    AIAssistant createWithPrompt(AIAssistantConfig config, Object toolProvider, SystemPrompt systemPrompt);
 
-    AIAssistant createForTest(AIAssistantConfig config, ToolProvider toolProvider);
+    AIAssistant createForTest(AIAssistantConfig config, Object toolProvider);
 
-    default AIAssistant createAIService(AIAssistantConfig config, ToolProvider toolProvider) {
+    default AIAssistant createAIService(AIAssistantConfig config, Object toolProvider) {
         return createWithPrompt(config, toolProvider, SystemPrompt.DEFAULT_PROMPT);
     }
 }

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/DashScopeAssistant.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/DashScopeAssistant.java
@@ -22,18 +22,28 @@ import org.apache.bigtop.manager.ai.core.AbstractAIAssistant;
 import org.apache.bigtop.manager.ai.core.enums.PlatformType;
 import org.apache.bigtop.manager.ai.core.factory.AIAssistant;
 
-import dev.langchain4j.community.model.dashscope.QwenChatModel;
-import dev.langchain4j.community.model.dashscope.QwenStreamingChatModel;
-import dev.langchain4j.internal.ValidationUtils;
-import dev.langchain4j.memory.ChatMemory;
-import dev.langchain4j.model.chat.ChatModel;
-import dev.langchain4j.model.chat.StreamingChatModel;
-import dev.langchain4j.service.AiServices;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.StreamingChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.util.Assert;
+import reactor.core.publisher.Flux;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class DashScopeAssistant extends AbstractAIAssistant {
 
-    public DashScopeAssistant(ChatMemory chatMemory, AIAssistant.Service aiServices) {
-        super(chatMemory, aiServices);
+    private static final String BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode";
+
+    public DashScopeAssistant(Object memoryId, ChatMemory chatMemory, AIAssistant.Service aiServices) {
+        super(memoryId, chatMemory, aiServices);
     }
 
     @Override
@@ -47,39 +57,94 @@ public class DashScopeAssistant extends AbstractAIAssistant {
 
     public static class Builder extends AbstractAIAssistant.Builder {
 
-        public AIAssistant build() {
-            AIAssistant.Service aiService = AiServices.builder(AIAssistant.Service.class)
-                    .chatModel(getChatModel())
-                    .streamingChatModel(getStreamingChatModel())
-                    .chatMemory(getChatMemory())
-                    .toolProvider(toolProvider)
-                    .systemMessageProvider(threadId -> {
-                        if (threadId != null) {
-                            return systemPrompt;
-                        }
-                        return null;
-                    })
-                    .build();
-            return new DashScopeAssistant(getChatMemory(), aiService);
-        }
-
         @Override
         public ChatModel getChatModel() {
-            String model = ValidationUtils.ensureNotNull(config.getModel(), "model");
-            String apiKey =
-                    ValidationUtils.ensureNotNull(config.getCredentials().get("apiKey"), "apiKey");
-            return QwenChatModel.builder().apiKey(apiKey).modelName(model).build();
+            String model = config.getModel();
+            Assert.notNull(model, "model must not be null");
+            String apiKey = config.getCredentials().get("apiKey");
+            Assert.notNull(apiKey, "apiKey must not be null");
+            
+            OpenAiApi openAiApi = OpenAiApi.builder()
+                    .baseUrl(BASE_URL)
+                    .apiKey(apiKey)
+                    .build();
+            OpenAiChatOptions options = OpenAiChatOptions.builder()
+                    .model(model)
+                    .build();
+            return OpenAiChatModel.builder()
+                    .openAiApi(openAiApi)
+                    .defaultOptions(options)
+                    .build();
         }
 
         @Override
         public StreamingChatModel getStreamingChatModel() {
-            String model = ValidationUtils.ensureNotNull(config.getModel(), "model");
-            String apiKey =
-                    ValidationUtils.ensureNotNull(config.getCredentials().get("apiKey"), "apiKey");
-            return QwenStreamingChatModel.builder()
-                    .apiKey(apiKey)
-                    .modelName(model)
-                    .build();
+            // In Spring AI, OpenAiChatModel handles both sync and streaming
+            return getChatModel();
+        }
+
+        public AIAssistant build() {
+            ChatModel chatModel = getChatModel();
+            StreamingChatModel streamingChatModel = getStreamingChatModel();
+            ChatMemory memory = getChatMemory();
+            
+            AIAssistant.Service aiService = new AIAssistant.Service() {
+                @Override
+                public String chat(String userMessage) {
+                    List<Message> messages = new ArrayList<>();
+                    if (systemPrompt != null) {
+                        messages.add(new SystemMessage(systemPrompt));
+                    }
+                    // Add conversation history
+                    String convId = String.valueOf(id);
+                    List<Message> history = memory.get(convId);
+                    messages.addAll(history);
+                    // Add new user message
+                    UserMessage newUserMessage = new UserMessage(userMessage);
+                    messages.add(newUserMessage);
+                    
+                    Prompt prompt = new Prompt(messages);
+                    String response = chatModel.call(prompt).getResult().getOutput().getText();
+                    
+                    // Save to memory
+                    memory.add(convId, List.of(newUserMessage, new org.springframework.ai.chat.messages.AssistantMessage(response)));
+                    
+                    return response;
+                }
+
+                @Override
+                public Flux<String> streamChat(String userMessage) {
+                    List<Message> messages = new ArrayList<>();
+                    if (systemPrompt != null) {
+                        messages.add(new SystemMessage(systemPrompt));
+                    }
+                    // Add conversation history
+                    String convId = String.valueOf(id);
+                    List<Message> history = memory.get(convId);
+                    messages.addAll(history);
+                    // Add new user message
+                    UserMessage newUserMessage = new UserMessage(userMessage);
+                    messages.add(newUserMessage);
+                    
+                    Prompt prompt = new Prompt(messages);
+                    
+                    StringBuilder responseBuilder = new StringBuilder();
+                    return streamingChatModel.stream(prompt)
+                            .map(chatResponse -> {
+                                String content = chatResponse.getResult().getOutput().getText();
+                                if (content != null) {
+                                    responseBuilder.append(content);
+                                }
+                                return content;
+                            })
+                            .doOnComplete(() -> {
+                                // Save to memory when streaming completes
+                                memory.add(convId, List.of(newUserMessage, new org.springframework.ai.chat.messages.AssistantMessage(responseBuilder.toString())));
+                            });
+                }
+            };
+            
+            return new DashScopeAssistant(id, memory, aiService);
         }
     }
 }

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/DashScopeAssistant.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/DashScopeAssistant.java
@@ -33,6 +33,7 @@ import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.util.Assert;
+
 import reactor.core.publisher.Flux;
 
 import java.util.ArrayList;
@@ -63,14 +64,10 @@ public class DashScopeAssistant extends AbstractAIAssistant {
             Assert.notNull(model, "model must not be null");
             String apiKey = config.getCredentials().get("apiKey");
             Assert.notNull(apiKey, "apiKey must not be null");
-            
-            OpenAiApi openAiApi = OpenAiApi.builder()
-                    .baseUrl(BASE_URL)
-                    .apiKey(apiKey)
-                    .build();
-            OpenAiChatOptions options = OpenAiChatOptions.builder()
-                    .model(model)
-                    .build();
+
+            OpenAiApi openAiApi =
+                    OpenAiApi.builder().baseUrl(BASE_URL).apiKey(apiKey).build();
+            OpenAiChatOptions options = OpenAiChatOptions.builder().model(model).build();
             return OpenAiChatModel.builder()
                     .openAiApi(openAiApi)
                     .defaultOptions(options)
@@ -87,7 +84,7 @@ public class DashScopeAssistant extends AbstractAIAssistant {
             ChatModel chatModel = getChatModel();
             StreamingChatModel streamingChatModel = getStreamingChatModel();
             ChatMemory memory = getChatMemory();
-            
+
             AIAssistant.Service aiService = new AIAssistant.Service() {
                 @Override
                 public String chat(String userMessage) {
@@ -102,13 +99,18 @@ public class DashScopeAssistant extends AbstractAIAssistant {
                     // Add new user message
                     UserMessage newUserMessage = new UserMessage(userMessage);
                     messages.add(newUserMessage);
-                    
+
                     Prompt prompt = new Prompt(messages);
-                    String response = chatModel.call(prompt).getResult().getOutput().getText();
-                    
+                    String response =
+                            chatModel.call(prompt).getResult().getOutput().getText();
+
                     // Save to memory
-                    memory.add(convId, List.of(newUserMessage, new org.springframework.ai.chat.messages.AssistantMessage(response)));
-                    
+                    memory.add(
+                            convId,
+                            List.of(
+                                    newUserMessage,
+                                    new org.springframework.ai.chat.messages.AssistantMessage(response)));
+
                     return response;
                 }
 
@@ -125,13 +127,14 @@ public class DashScopeAssistant extends AbstractAIAssistant {
                     // Add new user message
                     UserMessage newUserMessage = new UserMessage(userMessage);
                     messages.add(newUserMessage);
-                    
+
                     Prompt prompt = new Prompt(messages);
-                    
+
                     StringBuilder responseBuilder = new StringBuilder();
                     return streamingChatModel.stream(prompt)
                             .map(chatResponse -> {
-                                String content = chatResponse.getResult().getOutput().getText();
+                                String content =
+                                        chatResponse.getResult().getOutput().getText();
                                 if (content != null) {
                                     responseBuilder.append(content);
                                 }
@@ -139,11 +142,16 @@ public class DashScopeAssistant extends AbstractAIAssistant {
                             })
                             .doOnComplete(() -> {
                                 // Save to memory when streaming completes
-                                memory.add(convId, List.of(newUserMessage, new org.springframework.ai.chat.messages.AssistantMessage(responseBuilder.toString())));
+                                memory.add(
+                                        convId,
+                                        List.of(
+                                                newUserMessage,
+                                                new org.springframework.ai.chat.messages.AssistantMessage(
+                                                        responseBuilder.toString())));
                             });
                 }
             };
-            
+
             return new DashScopeAssistant(id, memory, aiService);
         }
     }

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/DeepSeekAssistant.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/DeepSeekAssistant.java
@@ -22,20 +22,28 @@ import org.apache.bigtop.manager.ai.core.AbstractAIAssistant;
 import org.apache.bigtop.manager.ai.core.enums.PlatformType;
 import org.apache.bigtop.manager.ai.core.factory.AIAssistant;
 
-import dev.langchain4j.internal.ValidationUtils;
-import dev.langchain4j.memory.ChatMemory;
-import dev.langchain4j.model.chat.ChatModel;
-import dev.langchain4j.model.chat.StreamingChatModel;
-import dev.langchain4j.model.openai.OpenAiChatModel;
-import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
-import dev.langchain4j.service.AiServices;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.StreamingChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.util.Assert;
+import reactor.core.publisher.Flux;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class DeepSeekAssistant extends AbstractAIAssistant {
 
-    private static final String BASE_URL = "https://api.deepseek.com/v1";
+    private static final String BASE_URL = "https://api.deepseek.com";
 
-    public DeepSeekAssistant(ChatMemory chatMemory, AIAssistant.Service aiServices) {
-        super(chatMemory, aiServices);
+    public DeepSeekAssistant(Object memoryId, ChatMemory chatMemory, AIAssistant.Service aiServices) {
+        super(memoryId, chatMemory, aiServices);
     }
 
     @Override
@@ -51,42 +59,92 @@ public class DeepSeekAssistant extends AbstractAIAssistant {
 
         @Override
         public ChatModel getChatModel() {
-            String model = ValidationUtils.ensureNotNull(config.getModel(), "model");
-            String apiKey =
-                    ValidationUtils.ensureNotNull(config.getCredentials().get("apiKey"), "apiKey");
-            return OpenAiChatModel.builder()
-                    .apiKey(apiKey)
+            String model = config.getModel();
+            Assert.notNull(model, "model must not be null");
+            String apiKey = config.getCredentials().get("apiKey");
+            Assert.notNull(apiKey, "apiKey must not be null");
+            
+            OpenAiApi openAiApi = OpenAiApi.builder()
                     .baseUrl(BASE_URL)
-                    .modelName(model)
+                    .apiKey(apiKey)
+                    .build();
+            OpenAiChatOptions options = OpenAiChatOptions.builder()
+                    .model(model)
+                    .build();
+            return OpenAiChatModel.builder()
+                    .openAiApi(openAiApi)
+                    .defaultOptions(options)
                     .build();
         }
 
         @Override
         public StreamingChatModel getStreamingChatModel() {
-            String model = ValidationUtils.ensureNotNull(config.getModel(), "model");
-            String apiKey =
-                    ValidationUtils.ensureNotNull(config.getCredentials().get("apiKey"), "apiKey");
-            return OpenAiStreamingChatModel.builder()
-                    .apiKey(apiKey)
-                    .baseUrl(BASE_URL)
-                    .modelName(model)
-                    .build();
+            // In Spring AI, OpenAiChatModel handles both sync and streaming
+            return getChatModel();
         }
 
         public AIAssistant build() {
-            AIAssistant.Service aiService = AiServices.builder(AIAssistant.Service.class)
-                    .chatModel(getChatModel())
-                    .streamingChatModel(getStreamingChatModel())
-                    .chatMemory(getChatMemory())
-                    .toolProvider(toolProvider)
-                    .systemMessageProvider(threadId -> {
-                        if (threadId != null) {
-                            return systemPrompt;
-                        }
-                        return null;
-                    })
-                    .build();
-            return new DeepSeekAssistant(getChatMemory(), aiService);
+            ChatModel chatModel = getChatModel();
+            StreamingChatModel streamingChatModel = getStreamingChatModel();
+            ChatMemory memory = getChatMemory();
+            
+            AIAssistant.Service aiService = new AIAssistant.Service() {
+                @Override
+                public String chat(String userMessage) {
+                    List<Message> messages = new ArrayList<>();
+                    if (systemPrompt != null) {
+                        messages.add(new SystemMessage(systemPrompt));
+                    }
+                    // Add conversation history
+                    String convId = String.valueOf(id);
+                    List<Message> history = memory.get(convId);
+                    messages.addAll(history);
+                    // Add new user message
+                    UserMessage newUserMessage = new UserMessage(userMessage);
+                    messages.add(newUserMessage);
+                    
+                    Prompt prompt = new Prompt(messages);
+                    String response = chatModel.call(prompt).getResult().getOutput().getText();
+                    
+                    // Save to memory
+                    memory.add(convId, List.of(newUserMessage, new org.springframework.ai.chat.messages.AssistantMessage(response)));
+                    
+                    return response;
+                }
+
+                @Override
+                public Flux<String> streamChat(String userMessage) {
+                    List<Message> messages = new ArrayList<>();
+                    if (systemPrompt != null) {
+                        messages.add(new SystemMessage(systemPrompt));
+                    }
+                    // Add conversation history
+                    String convId = String.valueOf(id);
+                    List<Message> history = memory.get(convId);
+                    messages.addAll(history);
+                    // Add new user message
+                    UserMessage newUserMessage = new UserMessage(userMessage);
+                    messages.add(newUserMessage);
+                    
+                    Prompt prompt = new Prompt(messages);
+                    
+                    StringBuilder responseBuilder = new StringBuilder();
+                    return streamingChatModel.stream(prompt)
+                            .map(chatResponse -> {
+                                String content = chatResponse.getResult().getOutput().getText();
+                                if (content != null) {
+                                    responseBuilder.append(content);
+                                }
+                                return content;
+                            })
+                            .doOnComplete(() -> {
+                                // Save to memory when streaming completes
+                                memory.add(convId, List.of(newUserMessage, new org.springframework.ai.chat.messages.AssistantMessage(responseBuilder.toString())));
+                            });
+                }
+            };
+            
+            return new DeepSeekAssistant(id, memory, aiService);
         }
     }
 }

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/DeepSeekAssistant.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/DeepSeekAssistant.java
@@ -33,6 +33,7 @@ import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.util.Assert;
+
 import reactor.core.publisher.Flux;
 
 import java.util.ArrayList;
@@ -63,14 +64,10 @@ public class DeepSeekAssistant extends AbstractAIAssistant {
             Assert.notNull(model, "model must not be null");
             String apiKey = config.getCredentials().get("apiKey");
             Assert.notNull(apiKey, "apiKey must not be null");
-            
-            OpenAiApi openAiApi = OpenAiApi.builder()
-                    .baseUrl(BASE_URL)
-                    .apiKey(apiKey)
-                    .build();
-            OpenAiChatOptions options = OpenAiChatOptions.builder()
-                    .model(model)
-                    .build();
+
+            OpenAiApi openAiApi =
+                    OpenAiApi.builder().baseUrl(BASE_URL).apiKey(apiKey).build();
+            OpenAiChatOptions options = OpenAiChatOptions.builder().model(model).build();
             return OpenAiChatModel.builder()
                     .openAiApi(openAiApi)
                     .defaultOptions(options)
@@ -87,7 +84,7 @@ public class DeepSeekAssistant extends AbstractAIAssistant {
             ChatModel chatModel = getChatModel();
             StreamingChatModel streamingChatModel = getStreamingChatModel();
             ChatMemory memory = getChatMemory();
-            
+
             AIAssistant.Service aiService = new AIAssistant.Service() {
                 @Override
                 public String chat(String userMessage) {
@@ -102,13 +99,18 @@ public class DeepSeekAssistant extends AbstractAIAssistant {
                     // Add new user message
                     UserMessage newUserMessage = new UserMessage(userMessage);
                     messages.add(newUserMessage);
-                    
+
                     Prompt prompt = new Prompt(messages);
-                    String response = chatModel.call(prompt).getResult().getOutput().getText();
-                    
+                    String response =
+                            chatModel.call(prompt).getResult().getOutput().getText();
+
                     // Save to memory
-                    memory.add(convId, List.of(newUserMessage, new org.springframework.ai.chat.messages.AssistantMessage(response)));
-                    
+                    memory.add(
+                            convId,
+                            List.of(
+                                    newUserMessage,
+                                    new org.springframework.ai.chat.messages.AssistantMessage(response)));
+
                     return response;
                 }
 
@@ -125,13 +127,14 @@ public class DeepSeekAssistant extends AbstractAIAssistant {
                     // Add new user message
                     UserMessage newUserMessage = new UserMessage(userMessage);
                     messages.add(newUserMessage);
-                    
+
                     Prompt prompt = new Prompt(messages);
-                    
+
                     StringBuilder responseBuilder = new StringBuilder();
                     return streamingChatModel.stream(prompt)
                             .map(chatResponse -> {
-                                String content = chatResponse.getResult().getOutput().getText();
+                                String content =
+                                        chatResponse.getResult().getOutput().getText();
                                 if (content != null) {
                                     responseBuilder.append(content);
                                 }
@@ -139,11 +142,16 @@ public class DeepSeekAssistant extends AbstractAIAssistant {
                             })
                             .doOnComplete(() -> {
                                 // Save to memory when streaming completes
-                                memory.add(convId, List.of(newUserMessage, new org.springframework.ai.chat.messages.AssistantMessage(responseBuilder.toString())));
+                                memory.add(
+                                        convId,
+                                        List.of(
+                                                newUserMessage,
+                                                new org.springframework.ai.chat.messages.AssistantMessage(
+                                                        responseBuilder.toString())));
                             });
                 }
             };
-            
+
             return new DeepSeekAssistant(id, memory, aiService);
         }
     }

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/DeepSeekAssistant.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/DeepSeekAssistant.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.bigtop.manager.ai.platform;
 
 import org.apache.bigtop.manager.ai.core.AbstractAIAssistant;
@@ -29,9 +30,9 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.StreamingChatModel;
 import org.springframework.ai.chat.prompt.Prompt;
-import org.springframework.ai.openai.OpenAiChatModel;
-import org.springframework.ai.openai.OpenAiChatOptions;
-import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.ai.deepseek.DeepSeekChatModel;
+import org.springframework.ai.deepseek.DeepSeekChatOptions;
+import org.springframework.ai.deepseek.api.DeepSeekApi;
 import org.springframework.util.Assert;
 
 import reactor.core.publisher.Flux;
@@ -40,8 +41,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class DeepSeekAssistant extends AbstractAIAssistant {
-
-    private static final String BASE_URL = "https://api.deepseek.com";
 
     public DeepSeekAssistant(Object memoryId, ChatMemory chatMemory, AIAssistant.Service aiServices) {
         super(memoryId, chatMemory, aiServices);
@@ -65,18 +64,18 @@ public class DeepSeekAssistant extends AbstractAIAssistant {
             String apiKey = config.getCredentials().get("apiKey");
             Assert.notNull(apiKey, "apiKey must not be null");
 
-            OpenAiApi openAiApi =
-                    OpenAiApi.builder().baseUrl(BASE_URL).apiKey(apiKey).build();
-            OpenAiChatOptions options = OpenAiChatOptions.builder().model(model).build();
-            return OpenAiChatModel.builder()
-                    .openAiApi(openAiApi)
+            DeepSeekApi deepSeekApi = DeepSeekApi.builder().apiKey(apiKey).build();
+            DeepSeekChatOptions options =
+                    DeepSeekChatOptions.builder().model(model).build();
+            return DeepSeekChatModel.builder()
+                    .deepSeekApi(deepSeekApi)
                     .defaultOptions(options)
                     .build();
         }
 
         @Override
         public StreamingChatModel getStreamingChatModel() {
-            // In Spring AI, OpenAiChatModel handles both sync and streaming
+            // DeepSeekChatModel handles both sync and streaming
             return getChatModel();
         }
 

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/OpenAIAssistant.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/OpenAIAssistant.java
@@ -33,6 +33,7 @@ import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.util.Assert;
+
 import reactor.core.publisher.Flux;
 
 import java.util.ArrayList;
@@ -63,14 +64,10 @@ public class OpenAIAssistant extends AbstractAIAssistant {
             Assert.notNull(model, "model must not be null");
             String apiKey = config.getCredentials().get("apiKey");
             Assert.notNull(apiKey, "apiKey must not be null");
-            
-            OpenAiApi openAiApi = OpenAiApi.builder()
-                    .baseUrl(BASE_URL)
-                    .apiKey(apiKey)
-                    .build();
-            OpenAiChatOptions options = OpenAiChatOptions.builder()
-                    .model(model)
-                    .build();
+
+            OpenAiApi openAiApi =
+                    OpenAiApi.builder().baseUrl(BASE_URL).apiKey(apiKey).build();
+            OpenAiChatOptions options = OpenAiChatOptions.builder().model(model).build();
             return OpenAiChatModel.builder()
                     .openAiApi(openAiApi)
                     .defaultOptions(options)
@@ -87,7 +84,7 @@ public class OpenAIAssistant extends AbstractAIAssistant {
             ChatModel chatModel = getChatModel();
             StreamingChatModel streamingChatModel = getStreamingChatModel();
             ChatMemory memory = getChatMemory();
-            
+
             AIAssistant.Service aiService = new AIAssistant.Service() {
                 @Override
                 public String chat(String userMessage) {
@@ -102,13 +99,18 @@ public class OpenAIAssistant extends AbstractAIAssistant {
                     // Add new user message
                     UserMessage newUserMessage = new UserMessage(userMessage);
                     messages.add(newUserMessage);
-                    
+
                     Prompt prompt = new Prompt(messages);
-                    String response = chatModel.call(prompt).getResult().getOutput().getText();
-                    
+                    String response =
+                            chatModel.call(prompt).getResult().getOutput().getText();
+
                     // Save to memory
-                    memory.add(convId, List.of(newUserMessage, new org.springframework.ai.chat.messages.AssistantMessage(response)));
-                    
+                    memory.add(
+                            convId,
+                            List.of(
+                                    newUserMessage,
+                                    new org.springframework.ai.chat.messages.AssistantMessage(response)));
+
                     return response;
                 }
 
@@ -125,13 +127,14 @@ public class OpenAIAssistant extends AbstractAIAssistant {
                     // Add new user message
                     UserMessage newUserMessage = new UserMessage(userMessage);
                     messages.add(newUserMessage);
-                    
+
                     Prompt prompt = new Prompt(messages);
-                    
+
                     StringBuilder responseBuilder = new StringBuilder();
                     return streamingChatModel.stream(prompt)
                             .map(chatResponse -> {
-                                String content = chatResponse.getResult().getOutput().getText();
+                                String content =
+                                        chatResponse.getResult().getOutput().getText();
                                 if (content != null) {
                                     responseBuilder.append(content);
                                 }
@@ -139,11 +142,16 @@ public class OpenAIAssistant extends AbstractAIAssistant {
                             })
                             .doOnComplete(() -> {
                                 // Save to memory when streaming completes
-                                memory.add(convId, List.of(newUserMessage, new org.springframework.ai.chat.messages.AssistantMessage(responseBuilder.toString())));
+                                memory.add(
+                                        convId,
+                                        List.of(
+                                                newUserMessage,
+                                                new org.springframework.ai.chat.messages.AssistantMessage(
+                                                        responseBuilder.toString())));
                             });
                 }
             };
-            
+
             return new OpenAIAssistant(id, memory, aiService);
         }
     }

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/OpenAIAssistant.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/OpenAIAssistant.java
@@ -22,20 +22,28 @@ import org.apache.bigtop.manager.ai.core.AbstractAIAssistant;
 import org.apache.bigtop.manager.ai.core.enums.PlatformType;
 import org.apache.bigtop.manager.ai.core.factory.AIAssistant;
 
-import dev.langchain4j.internal.ValidationUtils;
-import dev.langchain4j.memory.ChatMemory;
-import dev.langchain4j.model.chat.ChatModel;
-import dev.langchain4j.model.chat.StreamingChatModel;
-import dev.langchain4j.model.openai.OpenAiChatModel;
-import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
-import dev.langchain4j.service.AiServices;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.StreamingChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.util.Assert;
+import reactor.core.publisher.Flux;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class OpenAIAssistant extends AbstractAIAssistant {
 
-    private static final String BASE_URL = "https://api.openai.com/v1";
+    private static final String BASE_URL = "https://api.openai.com";
 
-    public OpenAIAssistant(ChatMemory chatMemory, AIAssistant.Service aiServices) {
-        super(chatMemory, aiServices);
+    public OpenAIAssistant(Object memoryId, ChatMemory chatMemory, AIAssistant.Service aiServices) {
+        super(memoryId, chatMemory, aiServices);
     }
 
     @Override
@@ -51,42 +59,92 @@ public class OpenAIAssistant extends AbstractAIAssistant {
 
         @Override
         public ChatModel getChatModel() {
-            String model = ValidationUtils.ensureNotNull(config.getModel(), "model");
-            String apiKey =
-                    ValidationUtils.ensureNotNull(config.getCredentials().get("apiKey"), "apiKey");
-            return OpenAiChatModel.builder()
-                    .apiKey(apiKey)
+            String model = config.getModel();
+            Assert.notNull(model, "model must not be null");
+            String apiKey = config.getCredentials().get("apiKey");
+            Assert.notNull(apiKey, "apiKey must not be null");
+            
+            OpenAiApi openAiApi = OpenAiApi.builder()
                     .baseUrl(BASE_URL)
-                    .modelName(model)
+                    .apiKey(apiKey)
+                    .build();
+            OpenAiChatOptions options = OpenAiChatOptions.builder()
+                    .model(model)
+                    .build();
+            return OpenAiChatModel.builder()
+                    .openAiApi(openAiApi)
+                    .defaultOptions(options)
                     .build();
         }
 
         @Override
         public StreamingChatModel getStreamingChatModel() {
-            String model = ValidationUtils.ensureNotNull(config.getModel(), "model");
-            String apiKey =
-                    ValidationUtils.ensureNotNull(config.getCredentials().get("apiKey"), "apiKey");
-            return OpenAiStreamingChatModel.builder()
-                    .apiKey(apiKey)
-                    .baseUrl(BASE_URL)
-                    .modelName(model)
-                    .build();
+            // In Spring AI, OpenAiChatModel handles both sync and streaming
+            return getChatModel();
         }
 
         public AIAssistant build() {
-            AIAssistant.Service aiService = AiServices.builder(AIAssistant.Service.class)
-                    .chatModel(getChatModel())
-                    .streamingChatModel(getStreamingChatModel())
-                    .chatMemory(getChatMemory())
-                    .toolProvider(toolProvider)
-                    .systemMessageProvider(threadId -> {
-                        if (threadId != null) {
-                            return systemPrompt;
-                        }
-                        return null;
-                    })
-                    .build();
-            return new OpenAIAssistant(getChatMemory(), aiService);
+            ChatModel chatModel = getChatModel();
+            StreamingChatModel streamingChatModel = getStreamingChatModel();
+            ChatMemory memory = getChatMemory();
+            
+            AIAssistant.Service aiService = new AIAssistant.Service() {
+                @Override
+                public String chat(String userMessage) {
+                    List<Message> messages = new ArrayList<>();
+                    if (systemPrompt != null) {
+                        messages.add(new SystemMessage(systemPrompt));
+                    }
+                    // Add conversation history
+                    String convId = String.valueOf(id);
+                    List<Message> history = memory.get(convId);
+                    messages.addAll(history);
+                    // Add new user message
+                    UserMessage newUserMessage = new UserMessage(userMessage);
+                    messages.add(newUserMessage);
+                    
+                    Prompt prompt = new Prompt(messages);
+                    String response = chatModel.call(prompt).getResult().getOutput().getText();
+                    
+                    // Save to memory
+                    memory.add(convId, List.of(newUserMessage, new org.springframework.ai.chat.messages.AssistantMessage(response)));
+                    
+                    return response;
+                }
+
+                @Override
+                public Flux<String> streamChat(String userMessage) {
+                    List<Message> messages = new ArrayList<>();
+                    if (systemPrompt != null) {
+                        messages.add(new SystemMessage(systemPrompt));
+                    }
+                    // Add conversation history
+                    String convId = String.valueOf(id);
+                    List<Message> history = memory.get(convId);
+                    messages.addAll(history);
+                    // Add new user message
+                    UserMessage newUserMessage = new UserMessage(userMessage);
+                    messages.add(newUserMessage);
+                    
+                    Prompt prompt = new Prompt(messages);
+                    
+                    StringBuilder responseBuilder = new StringBuilder();
+                    return streamingChatModel.stream(prompt)
+                            .map(chatResponse -> {
+                                String content = chatResponse.getResult().getOutput().getText();
+                                if (content != null) {
+                                    responseBuilder.append(content);
+                                }
+                                return content;
+                            })
+                            .doOnComplete(() -> {
+                                // Save to memory when streaming completes
+                                memory.add(convId, List.of(newUserMessage, new org.springframework.ai.chat.messages.AssistantMessage(responseBuilder.toString())));
+                            });
+                }
+            };
+            
+            return new OpenAIAssistant(id, memory, aiService);
         }
     }
 }

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/QianFanAssistant.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/QianFanAssistant.java
@@ -33,6 +33,7 @@ import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.util.Assert;
+
 import reactor.core.publisher.Flux;
 
 import java.util.ArrayList;
@@ -63,15 +64,11 @@ public class QianFanAssistant extends AbstractAIAssistant {
             Assert.notNull(model, "model must not be null");
             String apiKey = config.getCredentials().get("apiKey");
             Assert.notNull(apiKey, "apiKey must not be null");
-            
+
             // Using OpenAI API structure as fallback - QianFan may need custom implementation
-            OpenAiApi openAiApi = OpenAiApi.builder()
-                    .baseUrl(BASE_URL)
-                    .apiKey(apiKey)
-                    .build();
-            OpenAiChatOptions options = OpenAiChatOptions.builder()
-                    .model(model)
-                    .build();
+            OpenAiApi openAiApi =
+                    OpenAiApi.builder().baseUrl(BASE_URL).apiKey(apiKey).build();
+            OpenAiChatOptions options = OpenAiChatOptions.builder().model(model).build();
             return OpenAiChatModel.builder()
                     .openAiApi(openAiApi)
                     .defaultOptions(options)
@@ -88,7 +85,7 @@ public class QianFanAssistant extends AbstractAIAssistant {
             ChatModel chatModel = getChatModel();
             StreamingChatModel streamingChatModel = getStreamingChatModel();
             ChatMemory memory = getChatMemory();
-            
+
             AIAssistant.Service aiService = new AIAssistant.Service() {
                 @Override
                 public String chat(String userMessage) {
@@ -103,13 +100,18 @@ public class QianFanAssistant extends AbstractAIAssistant {
                     // Add new user message
                     UserMessage newUserMessage = new UserMessage(userMessage);
                     messages.add(newUserMessage);
-                    
+
                     Prompt prompt = new Prompt(messages);
-                    String response = chatModel.call(prompt).getResult().getOutput().getText();
-                    
+                    String response =
+                            chatModel.call(prompt).getResult().getOutput().getText();
+
                     // Save to memory
-                    memory.add(convId, List.of(newUserMessage, new org.springframework.ai.chat.messages.AssistantMessage(response)));
-                    
+                    memory.add(
+                            convId,
+                            List.of(
+                                    newUserMessage,
+                                    new org.springframework.ai.chat.messages.AssistantMessage(response)));
+
                     return response;
                 }
 
@@ -126,13 +128,14 @@ public class QianFanAssistant extends AbstractAIAssistant {
                     // Add new user message
                     UserMessage newUserMessage = new UserMessage(userMessage);
                     messages.add(newUserMessage);
-                    
+
                     Prompt prompt = new Prompt(messages);
-                    
+
                     StringBuilder responseBuilder = new StringBuilder();
                     return streamingChatModel.stream(prompt)
                             .map(chatResponse -> {
-                                String content = chatResponse.getResult().getOutput().getText();
+                                String content =
+                                        chatResponse.getResult().getOutput().getText();
                                 if (content != null) {
                                     responseBuilder.append(content);
                                 }
@@ -140,11 +143,16 @@ public class QianFanAssistant extends AbstractAIAssistant {
                             })
                             .doOnComplete(() -> {
                                 // Save to memory when streaming completes
-                                memory.add(convId, List.of(newUserMessage, new org.springframework.ai.chat.messages.AssistantMessage(responseBuilder.toString())));
+                                memory.add(
+                                        convId,
+                                        List.of(
+                                                newUserMessage,
+                                                new org.springframework.ai.chat.messages.AssistantMessage(
+                                                        responseBuilder.toString())));
                             });
                 }
             };
-            
+
             return new QianFanAssistant(id, memory, aiService);
         }
     }

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/QianFanAssistant.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/QianFanAssistant.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.bigtop.manager.ai.platform;
 
 import org.apache.bigtop.manager.ai.core.AbstractAIAssistant;
@@ -34,18 +33,15 @@ import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.util.Assert;
-import org.springframework.web.client.RestClient;
 
 import reactor.core.publisher.Flux;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public class QianFanAssistant extends AbstractAIAssistant {
 
-    private static final String BASE_URL = "https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat";
-    private static final String TOKEN_URL = "https://aip.baidubce.com/oauth/2.0/token";
+    private static final String BASE_URL = "https://qianfan.baidubce.com";
 
     public QianFanAssistant(Object memoryId, ChatMemory chatMemory, AIAssistant.Service aiServices) {
         super(memoryId, chatMemory, aiServices);
@@ -62,39 +58,18 @@ public class QianFanAssistant extends AbstractAIAssistant {
 
     public static class Builder extends AbstractAIAssistant.Builder {
 
-        private String getAccessToken(String apiKey, String secretKey) {
-            RestClient restClient = RestClient.create();
-            Map<String, Object> response = restClient
-                    .get()
-                    .uri(
-                            TOKEN_URL + "?grant_type=client_credentials&client_id={apiKey}&client_secret={secretKey}",
-                            apiKey,
-                            secretKey)
-                    .retrieve()
-                    .body(Map.class);
-
-            if (response != null && response.containsKey("access_token")) {
-                return (String) response.get("access_token");
-            }
-            throw new RuntimeException("Failed to obtain QianFan access token");
-        }
-
         @Override
         public ChatModel getChatModel() {
             String model = config.getModel();
             Assert.notNull(model, "model must not be null");
             String apiKey = config.getCredentials().get("apiKey");
             Assert.notNull(apiKey, "apiKey must not be null");
-            String secretKey = config.getCredentials().get("secretKey");
-            Assert.notNull(secretKey, "secretKey must not be null");
 
-            // Get access token from QianFan using apiKey and secretKey
-            String accessToken = getAccessToken(apiKey, secretKey);
-
-            // QianFan uses OpenAI-compatible API with access token
-            String qianfanUrl = BASE_URL + "/" + model + "?access_token=" + accessToken;
-            OpenAiApi openAiApi =
-                    OpenAiApi.builder().baseUrl(qianfanUrl).apiKey("dummy").build();
+            OpenAiApi openAiApi = OpenAiApi.builder()
+                    .baseUrl(BASE_URL)
+                    .completionsPath("/v2/chat/completions")
+                    .apiKey(apiKey)
+                    .build();
             OpenAiChatOptions options = OpenAiChatOptions.builder().model(model).build();
             return OpenAiChatModel.builder()
                     .openAiApi(openAiApi)
@@ -104,7 +79,6 @@ public class QianFanAssistant extends AbstractAIAssistant {
 
         @Override
         public StreamingChatModel getStreamingChatModel() {
-            // OpenAiChatModel handles both sync and streaming
             return getChatModel();
         }
 

--- a/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/QianFanAssistant.java
+++ b/bigtop-manager-ai/src/main/java/org/apache/bigtop/manager/ai/platform/QianFanAssistant.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.bigtop.manager.ai.platform;
 
 import org.apache.bigtop.manager.ai.core.AbstractAIAssistant;
@@ -33,15 +34,18 @@ import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.util.Assert;
+import org.springframework.web.client.RestClient;
 
 import reactor.core.publisher.Flux;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class QianFanAssistant extends AbstractAIAssistant {
 
     private static final String BASE_URL = "https://aip.baidubce.com/rpc/2.0/ai_custom/v1/wenxinworkshop/chat";
+    private static final String TOKEN_URL = "https://aip.baidubce.com/oauth/2.0/token";
 
     public QianFanAssistant(Object memoryId, ChatMemory chatMemory, AIAssistant.Service aiServices) {
         super(memoryId, chatMemory, aiServices);
@@ -58,16 +62,39 @@ public class QianFanAssistant extends AbstractAIAssistant {
 
     public static class Builder extends AbstractAIAssistant.Builder {
 
+        private String getAccessToken(String apiKey, String secretKey) {
+            RestClient restClient = RestClient.create();
+            Map<String, Object> response = restClient
+                    .get()
+                    .uri(
+                            TOKEN_URL + "?grant_type=client_credentials&client_id={apiKey}&client_secret={secretKey}",
+                            apiKey,
+                            secretKey)
+                    .retrieve()
+                    .body(Map.class);
+
+            if (response != null && response.containsKey("access_token")) {
+                return (String) response.get("access_token");
+            }
+            throw new RuntimeException("Failed to obtain QianFan access token");
+        }
+
         @Override
         public ChatModel getChatModel() {
             String model = config.getModel();
             Assert.notNull(model, "model must not be null");
             String apiKey = config.getCredentials().get("apiKey");
             Assert.notNull(apiKey, "apiKey must not be null");
+            String secretKey = config.getCredentials().get("secretKey");
+            Assert.notNull(secretKey, "secretKey must not be null");
 
-            // Using OpenAI API structure as fallback - QianFan may need custom implementation
+            // Get access token from QianFan using apiKey and secretKey
+            String accessToken = getAccessToken(apiKey, secretKey);
+
+            // QianFan uses OpenAI-compatible API with access token
+            String qianfanUrl = BASE_URL + "/" + model + "?access_token=" + accessToken;
             OpenAiApi openAiApi =
-                    OpenAiApi.builder().baseUrl(BASE_URL).apiKey(apiKey).build();
+                    OpenAiApi.builder().baseUrl(qianfanUrl).apiKey("dummy").build();
             OpenAiChatOptions options = OpenAiChatOptions.builder().model(model).build();
             return OpenAiChatModel.builder()
                     .openAiApi(openAiApi)
@@ -77,7 +104,7 @@ public class QianFanAssistant extends AbstractAIAssistant {
 
         @Override
         public StreamingChatModel getStreamingChatModel() {
-            // In Spring AI, OpenAiChatModel handles both sync and streaming
+            // OpenAiChatModel handles both sync and streaming
             return getChatModel();
         }
 

--- a/bigtop-manager-ai/src/test/java/assistant/GeneralAssistantFactoryTest.java
+++ b/bigtop-manager-ai/src/test/java/assistant/GeneralAssistantFactoryTest.java
@@ -58,7 +58,6 @@ class GeneralAssistantFactoryTest {
         when(mockBuilder.id(any())).thenReturn(mockBuilder);
         when(mockBuilder.memoryStore(any())).thenReturn(mockBuilder);
         when(mockBuilder.withConfig(any())).thenReturn(mockBuilder);
-        when(mockBuilder.withToolProvider(any())).thenReturn(mockBuilder);
         when(mockBuilder.withSystemPrompt(any())).thenReturn(mockBuilder);
         when(mockBuilder.build()).thenReturn(mock(AIAssistant.class));
 

--- a/bigtop-manager-ai/src/test/java/assistant/store/PersistentChatMemoryStoreTest.java
+++ b/bigtop-manager-ai/src/test/java/assistant/store/PersistentChatMemoryStoreTest.java
@@ -27,10 +27,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.SystemMessage;
@@ -130,7 +128,7 @@ class PersistentChatMemoryStoreTest {
         systemMessagePO.setMessage("Hello from System");
 
         when(chatMessageDao.findAllByThreadId(threadId)).thenReturn(List.of(systemMessagePO));
-        
+
         List<Message> result = persistentChatMemoryStore.findByConversationId(String.valueOf(threadId));
 
         assertEquals(1, result.size());

--- a/bigtop-manager-bom/pom.xml
+++ b/bigtop-manager-bom/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <spring-ai.version>1.0.0-RC1</spring-ai.version>
-        <spring-boot.version>3.1.1</spring-boot.version>
+        <spring-boot.version>3.2.0</spring-boot.version>
         <springdoc.version>2.2.0</springdoc.version>
         <freemarker.version>2.3.32</freemarker.version>
         <common-lang3.version>3.14.0</common-lang3.version>
@@ -52,8 +52,9 @@
         <micrometer.version>1.12.4</micrometer.version>
         <jdbc.dm.version>8.1.2.192</jdbc.dm.version>
         <sshd.version>2.15.0</sshd.version>
-        <langchain4j-core.version>1.0.1</langchain4j-core.version>
-        <langchain4j.version>1.0.1-beta6</langchain4j.version>
+        <langchain4j.version>1.0.1</langchain4j.version>
+        <jetbrains-annotations.version>24.0.1</jetbrains-annotations.version>
+
         <mybatis-spring-boot-starter.version>3.0.3</mybatis-spring-boot-starter.version>
         <pagehelper-spring-boot-starter.version>2.1.0</pagehelper-spring-boot-starter.version>
         <victools.version>4.29.0</victools.version>
@@ -261,19 +262,17 @@
                 <version>${grpc-spring-boot.version}</version>
             </dependency>
             <dependency>
-                <groupId>dev.langchain4j</groupId>
-                <artifactId>langchain4j</artifactId>
-                <version>${langchain4j-core.version}</version>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-bom</artifactId>
+                <version>${spring-ai.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
+
             <dependency>
-                <groupId>dev.langchain4j</groupId>
-                <artifactId>langchain4j-open-ai</artifactId>
-                <version>${langchain4j-core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>dev.langchain4j</groupId>
-                <artifactId>langchain4j-community-qianfan</artifactId>
-                <version>${langchain4j.version}</version>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-openai</artifactId>
+                <version>${spring-ai.version}</version>
             </dependency>
 
             <dependency>
@@ -282,22 +281,23 @@
                 <version>${spring-ai.version}</version>
             </dependency>
 
+            <!-- Keep langchain4j for server module tool support -->
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j</artifactId>
+                <version>${langchain4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains</groupId>
+                <artifactId>annotations</artifactId>
+                <version>${jetbrains-annotations.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>com.github.victools</groupId>
                 <artifactId>jsonschema-module-jackson</artifactId>
                 <version>${victools.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>dev.langchain4j</groupId>
-                <artifactId>langchain4j-community-dashscope</artifactId>
-                <version>${langchain4j.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>dev.langchain4j</groupId>
-                <artifactId>langchain4j-reactor</artifactId>
-                <version>${langchain4j.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/bigtop-manager-bom/pom.xml
+++ b/bigtop-manager-bom/pom.xml
@@ -277,6 +277,12 @@
 
             <dependency>
                 <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-deepseek</artifactId>
+                <version>${spring-ai.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-starter-mcp-server-webmvc</artifactId>
                 <version>${spring-ai.version}</version>
             </dependency>

--- a/bigtop-manager-bom/pom.xml
+++ b/bigtop-manager-bom/pom.xml
@@ -54,7 +54,6 @@
         <sshd.version>2.15.0</sshd.version>
         <langchain4j.version>1.0.1</langchain4j.version>
         <jetbrains-annotations.version>24.0.1</jetbrains-annotations.version>
-
         <mybatis-spring-boot-starter.version>3.0.3</mybatis-spring-boot-starter.version>
         <pagehelper-spring-boot-starter.version>2.1.0</pagehelper-spring-boot-starter.version>
         <victools.version>4.29.0</victools.version>

--- a/bigtop-manager-server/pom.xml
+++ b/bigtop-manager-server/pom.xml
@@ -64,6 +64,14 @@
             <artifactId>bigtop-manager-ai</artifactId>
         </dependency>
         <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.victools</groupId>
             <artifactId>jsonschema-module-jackson</artifactId>
         </dependency>

--- a/bigtop-manager-server/src/main/java/org/apache/bigtop/manager/server/controller/ChatbotController.java
+++ b/bigtop-manager-server/src/main/java/org/apache/bigtop/manager/server/controller/ChatbotController.java
@@ -62,7 +62,7 @@ public class ChatbotController {
     @Operation(summary = "update thread", description = "Update a chat thread")
     @PutMapping("/threads/{threadId}")
     public ResponseEntity<ChatThreadVO> updateChatThread(
-            @PathVariable Long threadId, @RequestBody ChatbotThreadReq chatbotThreadReq) {
+            @PathVariable(name = "threadId") Long threadId, @RequestBody ChatbotThreadReq chatbotThreadReq) {
         ChatThreadDTO chatThreadDTO = ChatThreadConverter.INSTANCE.fromReq2DTO(chatbotThreadReq);
         chatThreadDTO.setId(threadId);
         return ResponseEntity.success(chatbotService.updateChatThread(chatThreadDTO));
@@ -70,13 +70,13 @@ public class ChatbotController {
 
     @Operation(summary = "delete thread", description = "Delete a chat thread")
     @DeleteMapping("/threads/{threadId}")
-    public ResponseEntity<Boolean> deleteChatThread(@PathVariable Long threadId) {
+    public ResponseEntity<Boolean> deleteChatThread(@PathVariable(name = "threadId") Long threadId) {
         return ResponseEntity.success(chatbotService.deleteChatThread(threadId));
     }
 
     @Operation(summary = "get thread", description = "Get a chat thread")
     @GetMapping("/threads/{threadId}")
-    public ResponseEntity<ChatThreadVO> getChatThread(@PathVariable Long threadId) {
+    public ResponseEntity<ChatThreadVO> getChatThread(@PathVariable(name = "threadId") Long threadId) {
         return ResponseEntity.success(chatbotService.getChatThread(threadId));
     }
 
@@ -88,7 +88,7 @@ public class ChatbotController {
 
     @Operation(summary = "talk", description = "Talk with Chatbot")
     @PostMapping("/threads/{threadId}/talk")
-    public SseEmitter talk(@PathVariable Long threadId, @RequestBody ChatbotMessageReq messageReq) {
+    public SseEmitter talk(@PathVariable(name = "threadId") Long threadId, @RequestBody ChatbotMessageReq messageReq) {
         ChatbotCommand command = ChatbotCommand.getCommandFromMessage(messageReq.getMessage());
         if (command != null) {
             messageReq.setMessage(
@@ -99,7 +99,7 @@ public class ChatbotController {
 
     @Operation(summary = "history", description = "Get chat records")
     @GetMapping("/threads/{threadId}/history")
-    public ResponseEntity<List<ChatMessageVO>> history(@PathVariable Long threadId) {
+    public ResponseEntity<List<ChatMessageVO>> history(@PathVariable(name = "threadId") Long threadId) {
         return ResponseEntity.success(chatbotService.history(threadId));
     }
 

--- a/bigtop-manager-server/src/main/java/org/apache/bigtop/manager/server/controller/LLMConfigController.java
+++ b/bigtop-manager-server/src/main/java/org/apache/bigtop/manager/server/controller/LLMConfigController.java
@@ -64,7 +64,8 @@ public class LLMConfigController {
 
     @Operation(summary = "platform credentials", description = "Get platform auth credentials")
     @GetMapping("/platforms/{platformId}/auth-credentials")
-    public ResponseEntity<List<PlatformAuthCredentialVO>> platformsAuthCredential(@PathVariable(name = "platformId") Long platformId) {
+    public ResponseEntity<List<PlatformAuthCredentialVO>> platformsAuthCredential(
+            @PathVariable(name = "platformId") Long platformId) {
         return ResponseEntity.success(llmConfigService.platformsAuthCredentials(platformId));
     }
 

--- a/bigtop-manager-server/src/main/java/org/apache/bigtop/manager/server/controller/LLMConfigController.java
+++ b/bigtop-manager-server/src/main/java/org/apache/bigtop/manager/server/controller/LLMConfigController.java
@@ -58,13 +58,13 @@ public class LLMConfigController {
 
     @Operation(summary = "get platform", description = "Get platform")
     @GetMapping("/platforms/{id}")
-    public ResponseEntity<PlatformVO> getPlatform(@PathVariable Long id) {
+    public ResponseEntity<PlatformVO> getPlatform(@PathVariable(name = "id") Long id) {
         return ResponseEntity.success(llmConfigService.getPlatform(id));
     }
 
     @Operation(summary = "platform credentials", description = "Get platform auth credentials")
     @GetMapping("/platforms/{platformId}/auth-credentials")
-    public ResponseEntity<List<PlatformAuthCredentialVO>> platformsAuthCredential(@PathVariable Long platformId) {
+    public ResponseEntity<List<PlatformAuthCredentialVO>> platformsAuthCredential(@PathVariable(name = "platformId") Long platformId) {
         return ResponseEntity.success(llmConfigService.platformsAuthCredentials(platformId));
     }
 
@@ -91,7 +91,7 @@ public class LLMConfigController {
     @Operation(summary = "update auth platform", description = "Update authorized platform")
     @PutMapping("/auth-platforms/{authId}")
     public ResponseEntity<AuthPlatformVO> updateAuthorizedPlatform(
-            @PathVariable Long authId, @RequestBody AuthPlatformReq authPlatformReq) {
+            @PathVariable(name = "authId") Long authId, @RequestBody AuthPlatformReq authPlatformReq) {
         AuthPlatformDTO authPlatformDTO = AuthPlatformConverter.INSTANCE.fromReq2DTO(authPlatformReq);
         authPlatformDTO.setId(authId);
         return ResponseEntity.success(llmConfigService.updateAuthorizedPlatform(authPlatformDTO));
@@ -99,25 +99,25 @@ public class LLMConfigController {
 
     @Operation(summary = "get auth platform", description = "Get a authorized platform")
     @GetMapping("/auth-platforms/{authId}")
-    public ResponseEntity<AuthPlatformVO> getAuthorizedPlatform(@PathVariable Long authId) {
+    public ResponseEntity<AuthPlatformVO> getAuthorizedPlatform(@PathVariable(name = "authId") Long authId) {
         return ResponseEntity.success(llmConfigService.getAuthorizedPlatform(authId));
     }
 
     @Operation(summary = "delete auth platform", description = "Delete a authorized platform")
     @DeleteMapping("/auth-platforms/{authId}")
-    public ResponseEntity<Boolean> deleteAuthorizedPlatform(@PathVariable Long authId) {
+    public ResponseEntity<Boolean> deleteAuthorizedPlatform(@PathVariable(name = "authId") Long authId) {
         return ResponseEntity.success(llmConfigService.deleteAuthorizedPlatform(authId));
     }
 
     @Operation(summary = "activate auth platform", description = "Activate authorized platform")
     @PostMapping("/auth-platforms/{authId}/activate")
-    public ResponseEntity<Boolean> activateAuthorizedPlatform(@PathVariable Long authId) {
+    public ResponseEntity<Boolean> activateAuthorizedPlatform(@PathVariable(name = "authId") Long authId) {
         return ResponseEntity.success(llmConfigService.activateAuthorizedPlatform(authId));
     }
 
     @Operation(summary = "deactivate auth platform", description = "Deactivate authorized platform")
     @PostMapping("/auth-platforms/{authId}/deactivate")
-    public ResponseEntity<Boolean> deactivateAuthorizedPlatform(@PathVariable Long authId) {
+    public ResponseEntity<Boolean> deactivateAuthorizedPlatform(@PathVariable(name = "authId") Long authId) {
         return ResponseEntity.success(llmConfigService.deactivateAuthorizedPlatform(authId));
     }
 }

--- a/bigtop-manager-server/src/main/java/org/apache/bigtop/manager/server/controller/LoginController.java
+++ b/bigtop-manager-server/src/main/java/org/apache/bigtop/manager/server/controller/LoginController.java
@@ -36,6 +36,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -53,14 +54,14 @@ public class LoginController {
 
     @Operation(summary = "salt", description = "Generate salt")
     @GetMapping(value = "/salt")
-    public ResponseEntity<String> salt(String username) {
+    public ResponseEntity<String> salt(@RequestParam("username") String username) {
         String salt = Pbkdf2Utils.generateSalt(username);
         return ResponseEntity.success(salt);
     }
 
     @Operation(summary = "nonce", description = "Generate nonce")
     @GetMapping(value = "/nonce")
-    public ResponseEntity<String> nonce(String username) {
+    public ResponseEntity<String> nonce(@RequestParam("username") String username) {
         String nonce = PasswordUtils.randomString(16);
         String cacheKey = username + ":" + nonce;
         CacheUtils.setCache(Caches.CACHE_NONCE, cacheKey, nonce, Caches.NONCE_EXPIRE_TIME_MINUTES, TimeUnit.MINUTES);

--- a/bigtop-manager-server/src/main/java/org/apache/bigtop/manager/server/mcp/converter/JsonToolCallResultConverter.java
+++ b/bigtop-manager-server/src/main/java/org/apache/bigtop/manager/server/mcp/converter/JsonToolCallResultConverter.java
@@ -20,7 +20,6 @@ package org.apache.bigtop.manager.server.mcp.converter;
 
 import org.apache.bigtop.manager.common.utils.JsonUtils;
 
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.tool.execution.ToolCallResultConverter;
@@ -43,7 +42,7 @@ public class JsonToolCallResultConverter implements ToolCallResultConverter {
 
     private static final Logger logger = LoggerFactory.getLogger(JsonToolCallResultConverter.class);
 
-    @NotNull @Override
+    @Override
     public String convert(@Nullable Object result, @Nullable Type returnType) {
         if (returnType == Void.TYPE) {
             logger.debug("The tool has no return type. Converting to conventional response.");

--- a/bigtop-manager-server/src/main/resources/ddl/MySQL-DDL-CREATE.sql
+++ b/bigtop-manager-server/src/main/resources/ddl/MySQL-DDL-CREATE.sql
@@ -355,7 +355,7 @@ VALUES
 INSERT INTO llm_platform (credential, name, support_models)
 VALUES
 ('{"apiKey": "API Key"}', 'OpenAI', 'gpt-3.5-turbo,gpt-4,gpt-4o,gpt-3.5-turbo-16k,gpt-4-turbo-preview,gpt-4-32k,gpt-4o-mini'),
-('{"apiKey": "API Key"}', 'DashScope', 'qwen-1.8b-chat,qwen-max,qwen-plus,qwen-turbo,qwen3-235b-a22b,qwen3-30b-a3b,qwen-plus-latest,qwen-turbo-latest'),
+('{"apiKey": "API Key"}', 'DashScope', 'qwen-max,qwen-plus,qwen-turbo,qwen3-235b-a22b,qwen3-30b-a3b,qwen-plus-latest,qwen-turbo-latest'),
 ('{"apiKey": "API Key", "secretKey": "Secret Key"}', 'QianFan','Yi-34B-Chat,ERNIE-4.0-8K,ERNIE-3.5-128K,ERNIE-Speed-8K,Llama-2-7B-Chat,Fuyu-8B'),
 ('{"apiKey": "API Key"}','DeepSeek','deepseek-chat,deepseek-reasoner');
 

--- a/bigtop-manager-server/src/main/resources/ddl/MySQL-DDL-CREATE.sql
+++ b/bigtop-manager-server/src/main/resources/ddl/MySQL-DDL-CREATE.sql
@@ -356,7 +356,7 @@ INSERT INTO llm_platform (credential, name, support_models)
 VALUES
 ('{"apiKey": "API Key"}', 'OpenAI', 'gpt-3.5-turbo,gpt-4,gpt-4o,gpt-3.5-turbo-16k,gpt-4-turbo-preview,gpt-4-32k,gpt-4o-mini'),
 ('{"apiKey": "API Key"}', 'DashScope', 'qwen-max,qwen-plus,qwen-turbo,qwen3-235b-a22b,qwen3-30b-a3b,qwen-plus-latest,qwen-turbo-latest'),
-('{"apiKey": "API Key", "secretKey": "Secret Key"}', 'QianFan','Yi-34B-Chat,ERNIE-4.0-8K,ERNIE-3.5-128K,ERNIE-Speed-8K,Llama-2-7B-Chat,Fuyu-8B'),
+('{"apiKey": "API Key"}', 'QianFan','ernie-speed-8k'),
 ('{"apiKey": "API Key"}','DeepSeek','deepseek-chat,deepseek-reasoner');
 
 UPDATE `llm_platform`
@@ -368,7 +368,7 @@ SET `desc` = 'Get your API Key in https://bailian.console.aliyun.com/?apiKey=1#/
 WHERE `name` = 'DashScope';
 
 UPDATE `llm_platform`
-SET `desc` = 'Get API Key and Secret Key in https://console.bce.baidu.com/qianfan/ais/console/applicationConsole/application/v1'
+SET `desc` = 'Get API Key and Secret Key in https://console.bce.baidu.com/iam/#/iam/apikey/list'
 WHERE `name` = 'QianFan';
 
 UPDATE `llm_platform`

--- a/bigtop-manager-server/src/main/resources/ddl/PostgreSQL-DDL-CREATE.sql
+++ b/bigtop-manager-server/src/main/resources/ddl/PostgreSQL-DDL-CREATE.sql
@@ -366,7 +366,7 @@ VALUES
 INSERT INTO llm_platform (credential, name, support_models)
 VALUES
 ('{"apiKey": "API Key"}','OpenAI','gpt-3.5-turbo,gpt-4,gpt-4o,gpt-3.5-turbo-16k,gpt-4-turbo-preview,gpt-4-32k,gpt-4o-mini'),
-('{"apiKey": "API Key"}','DashScope','qwen-1.8b-chat,qwen-max,qwen-plus,qwen-turbo,qwen3-235b-a22b,qwen3-30b-a3b,qwen-plus-latest,qwen-turbo-latest'),
+('{"apiKey": "API Key"}','DashScope','qwen-max,qwen-plus,qwen-turbo,qwen3-235b-a22b,qwen3-30b-a3b,qwen-plus-latest,qwen-turbo-latest'),
 ('{"apiKey": "API Key", "secretKey": "Secret Key"}','QianFan','Yi-34B-Chat,ERNIE-4.0-8K,ERNIE-3.5-128K,ERNIE-Speed-8K,Llama-2-7B-Chat,Fuyu-8B'),
 ('{"apiKey": "API Key"}','DeepSeek','deepseek-chat,deepseek-reasoner');
 

--- a/bigtop-manager-server/src/main/resources/ddl/PostgreSQL-DDL-CREATE.sql
+++ b/bigtop-manager-server/src/main/resources/ddl/PostgreSQL-DDL-CREATE.sql
@@ -367,7 +367,7 @@ INSERT INTO llm_platform (credential, name, support_models)
 VALUES
 ('{"apiKey": "API Key"}','OpenAI','gpt-3.5-turbo,gpt-4,gpt-4o,gpt-3.5-turbo-16k,gpt-4-turbo-preview,gpt-4-32k,gpt-4o-mini'),
 ('{"apiKey": "API Key"}','DashScope','qwen-max,qwen-plus,qwen-turbo,qwen3-235b-a22b,qwen3-30b-a3b,qwen-plus-latest,qwen-turbo-latest'),
-('{"apiKey": "API Key", "secretKey": "Secret Key"}','QianFan','Yi-34B-Chat,ERNIE-4.0-8K,ERNIE-3.5-128K,ERNIE-Speed-8K,Llama-2-7B-Chat,Fuyu-8B'),
+('{"apiKey": "API Key"}', 'QianFan','ernie-speed-8k'),
 ('{"apiKey": "API Key"}','DeepSeek','deepseek-chat,deepseek-reasoner');
 
 UPDATE llm_platform
@@ -379,7 +379,7 @@ SET "desc" = 'Get your API Key in https://bailian.console.aliyun.com/?apiKey=1#/
 WHERE "name" = 'DashScope';
 
 UPDATE llm_platform
-SET "desc" = 'Get API Key and Secret Key in https://console.bce.baidu.com/qianfan/ais/console/applicationConsole/application/v1'
+SET "desc" = 'Get API Key and Secret Key in https://console.bce.baidu.com/iam/#/iam/apikey/list'
 WHERE "name" = 'QianFan';
 
 UPDATE llm_platform


### PR DESCRIPTION
## Migration Plan: Replace LangChain4j with Spring AI

This PR migrates the AI module from **LangChain4j** to **Spring AI**, aligning the implementation with the Spring ecosystem and simplifying future maintenance.

### Completed Tasks

- [x] Update BOM dependencies  
  - Remove `langchain4j`
  - Add required Spring AI modules
- [x] Update `bigtop-manager-ai` module dependencies in `pom.xml`
- [x] Refactor core interfaces and abstractions
  - [x] Update `AIAssistant` interface to use Spring AI types
  - [x] Update `AbstractAIAssistant` to use Spring AI types
  - [x] Update `PersistentChatMemoryStore` to implement `ChatMemoryRepository`
- [x] Migrate platform implementations
  - [x] `OpenAIAssistant` – migrated to Spring AI OpenAI client
  - [x] `DeepSeekAssistant` – implemented using Spring AI
  - [x] `QianFanAssistant` – implemented using Spring AI
  - [x] `DashScopeAssistant` – implemented using Spring AI
- [x] Update tests
  - [x] `PersistentChatMemoryStoreTest`
  - [x] `GeneralAssistantFactoryTest`
  - [x] All tests passing
- [x] Build and verify
  - [x] AI module builds and tests successfully
  - [x] Fixed `RestClient` dependency issue by upgrading Spring Boot

### Pending Tasks

- [x] Manual runtime verification
  - [x] `DashScopeAssistant`
  - [ ] `OpenAIAssistant`
  - [x] `DeepSeekAssistant`
  - [x] `QianFanAssistant`
- [ ] Refactor function-calling support
  - Reimplement using Spring AI APIs, or
  - Introduce a lightweight MCP-based client

---

## Implementation Notes

### AI Module Migration

- Migrated from **LangChain4j** to **Spring AI `1.0.0-RC1`**
- Replaced `ChatMemoryStore` with Spring AI’s `ChatMemoryRepository`
- A single `OpenAiChatModel` supports both synchronous and streaming calls

---

### Server Module

- Retained **LangChain4j** dependencies for tool/function calling:
  - `ToolProvider`
  - `ToolSpecification`
  - `ToolExecutor`
- Tool migration to Spring AI is **out of scope** for this PR
- Added required dependencies:
  - `dev.langchain4j:langchain4j`
  - `org.jetbrains:annotations`

---


### Dependency Updates

- **Spring Boot** upgraded from `3.1.1` to `3.2.0`
  - Required for **Spring Framework 6.1+**
  - `RestClient` was introduced in Spring Framework 6.1
  - Spring AI OpenAI integration depends on `RestClient`
  - All tests pass after the upgrade
- **Note**:
  - After upgrading, `@PathVariable` annotations must explicitly specify the parameter name  
    (e.g. `@PathVariable(name = "id")`)
    
---

thank copilot~

